### PR TITLE
Enhanced RTL Support for few components

### DIFF
--- a/resources/css/theme.css
+++ b/resources/css/theme.css
@@ -152,7 +152,7 @@
     
             > .fi-sidebar-group  {
                 > .fi-sidebar-group-button {
-                    @apply pl-14 pr-6 mt-2;
+                    @apply pl-14 pr-6 mt-2 rtl:pl-6 rtl:pr-14;
     
                     > .fi-icon-btn, > .fi-sidebar-group-label {
                         @apply text-gray-600 dark:text-gray-300;
@@ -161,8 +161,7 @@
     
                 > .fi-sidebar-group-items {
                     > .fi-sidebar-item {
-                        @apply relative;
-                        @apply px-10;
+                        @apply relative px-10 rtl:pr-14 rtl:pl-6;
     
                         > .fi-sidebar-item-button {
                             @apply bg-white dark:bg-[var(--ds-dark-bg-secondary-color)];
@@ -190,7 +189,7 @@
     
                     > .fi-sidebar-item::after {
                         content: '';
-                        @apply absolute left-0 top-0 w-4 h-full rounded-lg;
+                        @apply absolute left-0 rtl:right-4 top-0 w-4 h-full rounded-lg;
                     }
     
                     > .fi-sidebar-item.fi-sidebar-item-active::after {
@@ -228,7 +227,7 @@
     
             > .fi-sidebar-group  {
                 > .fi-sidebar-group-button {
-                    @apply pl-14 pr-6 mt-2;
+                    @apply pl-14 pr-6 mt-2 rtl:pl-6 rtl:pr-14;
     
                     > .fi-icon-btn, > .fi-sidebar-group-label {
                         @apply text-gray-600 dark:text-gray-300;
@@ -237,7 +236,7 @@
     
                 > .fi-sidebar-group-items {
                     > .fi-sidebar-item {
-                        @apply relative;
+                        @apply relative rtl:pr-8;
 
                         > .fi-sidebar-item-button {
                             @apply bg-white dark:bg-[var(--ds-dark-bg-secondary-color)];
@@ -259,7 +258,7 @@
      
                     > .fi-sidebar-item::after {
                         content: '';
-                        @apply absolute left-0 top-0 w-4 h-full rounded-lg;
+                        @apply absolute left-0 rtl:right-4 top-0 w-4 h-full rounded-lg;
                     }
     
                     > .fi-sidebar-item.fi-sidebar-item-active::after {
@@ -359,12 +358,12 @@
                         &:only-child {
                             .fi-ta-header-cell:first-child,
                             .fi-ta-cell {
-                                @apply rounded-l-2xl;
+                                @apply ltr:rounded-l-2xl rtl:rounded-r-2xl;
                             }
 
                             .fi-ta-header-cell:last-child,
                             .fi-ta-actions-header-cell {
-                                @apply rounded-r-2xl;
+                                @apply ltr:rounded-r-2xl rtl:rounded-l-2xl;
                             }
                         }
 
@@ -376,11 +375,11 @@
                                     @apply border-none bg-primary-100/10;
 
                                     &:first-child {
-                                        @apply rounded-tl-2xl;
+                                        @apply ltr:rounded-tl-2xl rtl:rounded-tr-2xl;
                                     }
 
                                     &:last-child {
-                                        @apply rounded-tr-2xl;
+                                        @apply ltr:rounded-tr-2xl rtl:rounded-tl-2xl;
                                     }
                                 }
                             }
@@ -390,11 +389,11 @@
                                     @apply border-none;
 
                                     &:first-child {
-                                        @apply rounded-bl-2xl;
+                                        @apply ltr:rounded-bl-2xl rtl:rounded-br-2xl;
                                     }
 
                                     &:last-child {
-                                        @apply rounded-br-2xl;
+                                        @apply ltr:rounded-br-2xl rtl:rounded-bl-2xl;
                                     }
                                 }
                             }
@@ -410,22 +409,22 @@
 
                         &.fi-ta-summary-header-row {
                             & > td:first-child {
-                                @apply rounded-l-2xl;
+                                @apply ltr:rounded-l-2xl rtl:rounded-r-2xl;
                             }
 
                             & > td:last-child {
-                                @apply rounded-r-2xl;
+                                @apply ltr:rounded-r-2xl rtl:rounded-l-2xl;
                             }
                         }
                     }
 
                     .fi-ta-cell {
                         &:first-child {
-                            @apply rounded-l-2xl;
+                            @apply ltr:rounded-l-2xl rtl:rounded-r-2xl;
                         }
 
                         &:last-child {
-                            @apply rounded-r-2xl;
+                            @apply ltr:rounded-r-2xl rtl:rounded-l-2xl;
                         }
 
                         .fi-input-wrp {
@@ -551,6 +550,12 @@
 .fi-modal-window {
     @apply bg-white dark:bg-[var(--ds-dark-bg-secondary-color)];
 
+    &:not(.fi-modal-slide-over-window) {
+        > .fi-modal-header {
+            @apply rounded-tl-2xl rounded-tr-2xl;
+        }
+    }
+
     > .fi-modal-header {
         @apply bg-white dark:bg-[var(--ds-dark-bg-secondary-color)];
 
@@ -570,7 +575,7 @@
                 @apply border-none my-2;
 
                 &::before {
-                    @apply rounded-lg w-3 -translate-x-1/2 h-[90%] top-1/2 -translate-y-1/2;
+                    @apply rounded-lg w-3 -translate-x-1/2 rtl:translate-x-1/2 h-[90%] top-1/2 -translate-y-1/2 left-0;
                 }
             }
             /* Notification Wrapper End */


### PR DESCRIPTION
This pull request includes several changes to the `resources/css/theme.css` file to improve RTL (right-to-left) language support. The most important changes include adding RTL-specific styles for sidebar groups, sidebar items, table cells, and modal windows.

Improvements for RTL support:

* Added RTL-specific padding and margin adjustments for `.fi-sidebar-group-button` and `.fi-sidebar-item` elements. [[1]](diffhunk://#diff-2689cd85a6be280d1afce5c6c95f1a46fad37a1afc1daa2ea4effa0ca6dddd33L155-R155) [[2]](diffhunk://#diff-2689cd85a6be280d1afce5c6c95f1a46fad37a1afc1daa2ea4effa0ca6dddd33L164-R164) [[3]](diffhunk://#diff-2689cd85a6be280d1afce5c6c95f1a46fad37a1afc1daa2ea4effa0ca6dddd33L231-R230) [[4]](diffhunk://#diff-2689cd85a6be280d1afce5c6c95f1a46fad37a1afc1daa2ea4effa0ca6dddd33L240-R239)
* Adjusted the placement of the pseudo-element for `.fi-sidebar-item::after` to support RTL layouts. [[1]](diffhunk://#diff-2689cd85a6be280d1afce5c6c95f1a46fad37a1afc1daa2ea4effa0ca6dddd33L193-R192) [[2]](diffhunk://#diff-2689cd85a6be280d1afce5c6c95f1a46fad37a1afc1daa2ea4effa0ca6dddd33L262-R261)
* Applied RTL-specific border-radius styles for table cells to ensure proper rounding in RTL layouts. [[1]](diffhunk://#diff-2689cd85a6be280d1afce5c6c95f1a46fad37a1afc1daa2ea4effa0ca6dddd33L362-R366) [[2]](diffhunk://#diff-2689cd85a6be280d1afce5c6c95f1a46fad37a1afc1daa2ea4effa0ca6dddd33L379-R382) [[3]](diffhunk://#diff-2689cd85a6be280d1afce5c6c95f1a46fad37a1afc1daa2ea4effa0ca6dddd33L393-R396) [[4]](diffhunk://#diff-2689cd85a6be280d1afce5c6c95f1a46fad37a1afc1daa2ea4effa0ca6dddd33L413-R427)
* Added rounded corners to modal headers, excluding slide-over windows, for a consistent appearance.
* Corrected the translation of the `::before` pseudo-element for notification wrappers in RTL layouts.